### PR TITLE
Update phone authentication input handling and language files

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -94,6 +94,7 @@
   "phone.body.text.a": "Enter the three one-time passwords (OTP) from the SMS you received. Match the numbers in the text (#1, #2, #3) to verify.",
   "phone.body.text.b": "Expiring in",
   "phone.body.input.a": "Country code number",
+  "phone.body.input.b": "Enter the OTP code",
 
   "shop.alert.reg.fail": "Your store/shop registration failed.",
   "shop.alert.reg.done": "Your store/shop is registered successfully.",

--- a/langs/ko.json
+++ b/langs/ko.json
@@ -93,6 +93,7 @@
   "phone.body.text.a": "전화번호 전송 후에 문자 메세지의 인증 코드 3개를 문자에 표시된 번호(#1, #2, #3)에 맞추어 입력하고 인증을 진행해 주세요.",
   "phone.body.text.b": "유효시간",
   "phone.body.input.a": "국가 코드 번호",
+  "phone.body.input.b": "인증 코드 입력",
 
   "shop.alert.reg.fail": "상점 등록에 실패하였습니다.",
   "shop.alert.reg.done": "상점이 등록 되었습니다.",

--- a/screens/initScreens/PhoneAuth.js
+++ b/screens/initScreens/PhoneAuth.js
@@ -23,30 +23,16 @@ import {
 import { WrapButton } from '../../components/styled/button';
 
 const registerSchema = yup.object().shape({
-  n1: yup
+  authCode: yup
     .string()
     .required()
     .matches(/^[0-9]+$/, 'Must be only digits')
-    .min(2, 'Must be exactly 2 digits')
-    .max(2, 'Must be exactly 2 digits'),
-  n2: yup
-    .string()
-    .required()
-    .matches(/^[0-9]+$/, 'Must be only digits')
-    .min(2, 'Must be exactly 2 digits')
-    .max(2, 'Must be exactly 2 digits'),
-  n3: yup
-    .string()
-    .required()
-    .matches(/^[0-9]+$/, 'Must be only digits')
-    .min(2, 'Must be exactly 2 digits')
-    .max(2, 'Must be exactly 2 digits'),
+    .min(6, 'Must be exactly 6 digits')
+    .max(6, 'Must be exactly 6 digits'),
 });
 
 const registerInitialValues = {
-  n1: '',
-  n2: '',
-  n3: '',
+  authCode: '',
 };
 
 const PhoneAuth = observer(({ navigation }) => {
@@ -214,8 +200,7 @@ const PhoneAuth = observer(({ navigation }) => {
 
     onSubmit: (values, { resetForm }) => {
       console.log('form values :', values);
-      const authNums = values.n1 + values.n2 + values.n3;
-      submitPhone(authNums)
+      submitPhone(values.authCode)
         .then((r) => {
           if (r === true) {
             completeAuth();
@@ -318,7 +303,7 @@ const PhoneAuth = observer(({ navigation }) => {
                 {timeLeft.s}
               </RobotoRegularText>
             ) : null}
-            <FormControl isRequired={true} isInvalid={!!formik.errors.n1}>
+            <FormControl isRequired={true} isInvalid={!!formik.errors.authCode}>
               <Input
                 mt={5}
                 style={{
@@ -334,62 +319,11 @@ const PhoneAuth = observer(({ navigation }) => {
                     color: '#12121D',
                   }}
                   keyboardType='number-pad'
-                  placeholder='#1'
-                  onChangeText={formik.handleChange('n1')}
-                  onBlur={formik.handleBlur('n1')}
-                  value={formik.values?.n1}
-                />
-              </Input>
-            </FormControl>
-            <FormControl
-              size='md'
-              isRequired={true}
-              isInvalid={!!formik.errors.n2}>
-              <Input
-                mt={5}
-                style={{
-                  height: 48,
-                  borderWidth: 1,
-                  borderColor: '#E4E4E4',
-                }}>
-                <InputField
-                  style={{
-                    fontFamily: 'Roboto-Medium',
-                    lineHeight: 20,
-                    fontSize: 15,
-                    color: '#12121D',
-                  }}
-                  keyboardType='number-pad'
-                  placeholder='#2'
-                  onChangeText={formik.handleChange('n2')}
-                  onBlur={formik.handleBlur('n2')}
-                  value={formik.values?.n2}
-                />
-              </Input>
-            </FormControl>
-            <FormControl
-              size='md'
-              isRequired={true}
-              isInvalid={!!formik.errors.n3}>
-              <Input
-                mt={5}
-                style={{
-                  height: 48,
-                  borderWidth: 1,
-                  borderColor: '#E4E4E4',
-                }}>
-                <InputField
-                  style={{
-                    fontFamily: 'Roboto-Medium',
-                    lineHeight: 20,
-                    fontSize: 15,
-                    color: '#12121D',
-                  }}
-                  keyboardType='number-pad'
-                  placeholder='#3'
-                  onChangeText={formik.handleChange('n3')}
-                  onBlur={formik.handleBlur('n3')}
-                  value={formik.values?.n3}
+                  textContentType="oneTimeCode"
+                  placeholder={t('phone.body.input.b')}
+                  onChangeText={formik.handleChange('authCode')}
+                  onBlur={formik.handleBlur('authCode')}
+                  value={formik.values?.authCode}
                 />
               </Input>
             </FormControl>


### PR DESCRIPTION
- Refactored PhoneAuth.js to consolidate OTP input into a single field for better user experience.
- Updated validation schema to require a 6-digit OTP code instead of three separate 2-digit inputs.
- Modified English and Korean language files to include a new prompt for entering the OTP code.